### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 %%VERSION%%
 
-Provide random byte vectors (the V1_LWT.RANDOM interface) using the Random
+Provide random byte vectors (the Mirage_types_lwt.RANDOM interface) using the Random
 interface.

--- a/src/stdlibrandom.mli
+++ b/src/stdlibrandom.mli
@@ -1,5 +1,5 @@
 
-include V1_LWT.RANDOM
+include Mirage_types_lwt.RANDOM
   with type buffer = Cstruct.t
 
 val initialize : unit -> unit


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.